### PR TITLE
Support clang-format setting executablefile path

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Run 'clang-format' on save."
+                },
+                "clang-format.executable":{
+                    "type":"string",
+                    "default":"clang-format",
+                    "description": "clang-format command or the path to the clang-format executable"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
                     "default": false,
                     "description": "Run 'clang-format' on save."
                 },
-                "clang-format.executable":{
-                    "type":"string",
-                    "default":"clang-format",
+                "clang-format.executable": {
+                    "type": "string",
+                    "default": "clang-format",
                     "description": "clang-format command or the path to the clang-format executable"
                 }
             }

--- a/src/clangPath.ts
+++ b/src/clangPath.ts
@@ -2,11 +2,17 @@
 
 import fs = require('fs');
 import path = require('path');
+import vscode = require('vscode');
 
 var binPathCache: { [bin: string]: string; } = {}
 
 export function getBinPath(binname: string) {
 	binname = correctBinname(binname);
+    binname =  vscode.workspace.getConfiguration('clang-format').get<string>("executable");
+    if(fs.existsSync(binname)){
+        binPathCache[binname]=binname;
+        return binname;
+    }
 	if (binPathCache[binname]) return binPathCache[binname];
 
 	if (process.env["PATH"]) {

--- a/src/clangPath.ts
+++ b/src/clangPath.ts
@@ -7,33 +7,33 @@ import vscode = require('vscode');
 var binPathCache: { [bin: string]: string; } = {}
 
 export function getBinPath(binname: string) {
-	binname = correctBinname(binname);
-    binname =  vscode.workspace.getConfiguration('clang-format').get<string>("executable");
-    if(fs.existsSync(binname)){
-        binPathCache[binname]=binname;
+    binname = correctBinname(binname);
+    binname = vscode.workspace.getConfiguration('clang-format').get<string>("executable");
+    if (fs.existsSync(binname)) {
+        binPathCache[binname] = binname;
         return binname;
     }
-	if (binPathCache[binname]) return binPathCache[binname];
+    if (binPathCache[binname]) return binPathCache[binname];
 
-	if (process.env["PATH"]) {
-		var pathparts = process.env["PATH"].split(path.delimiter);
-		for (var i = 0; i < pathparts.length; i++) {
-			let binpath = path.join(pathparts[i], binname);
-			if (fs.existsSync(binpath)) {
-				binPathCache[binname] = binpath;
-				return binpath;
-			}
-		}
-	}
+    if (process.env["PATH"]) {
+        var pathparts = process.env["PATH"].split(path.delimiter);
+        for (var i = 0; i < pathparts.length; i++) {
+            let binpath = path.join(pathparts[i], binname);
+            if (fs.existsSync(binpath)) {
+                binPathCache[binname] = binpath;
+                return binpath;
+            }
+        }
+    }
 
-	// Else return the binary name directly (this will likely always fail downstream) 
-	binPathCache[binname] = binname;
-	return binname;
+    // Else return the binary name directly (this will likely always fail downstream) 
+    binPathCache[binname] = binname;
+    return binname;
 }
 
 function correctBinname(binname: string) {
-	if (process.platform === 'win32')
-		return binname + ".exe";
-	else
-		return binname
+    if (process.platform === 'win32')
+        return binname + ".exe";
+    else
+        return binname
 }


### PR DESCRIPTION
On Windows, maybe user not add clang-format.exe directory add to PATH, this commit support user is able to setting clang-format's full Path.


Thank your ext