### PR TITLE
Evaluate placeholders in "clang-format.executable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,52 @@
 
 
 ## Usage
-If clang-format is installed and in PATH, C/C++ etc source files can be formatted with Visual Studio Code's built-in formatter (Usually: Ctrl+Shift+F).
+
+This extension allows clang-format to be used to format C/C++, Javascript etc. 
+source files directly from within Visual Studio Code.
+
+Files can be formatted on-demand by right clicking in the document and
+selecting "Format Document", or by using the associated keyboard shortcut
+(usually Ctrl+Shift+F on Windows/Linux, and Cmd+Shift+F on Mac).
+
+To automatically format a file on save, add the following to your
+vscode settings.json file:
+
+```json
+{
+    // ...
+    "editor.formatOnSave": true
+}
+```
+
+## Specifying the location of clang-format
+
+This extension will attempt to find clang-format on your `PATH`.
+Alternatively, the clang-format executable can be specified in your vscode
+settings.json file:
+
+```json
+{
+    // ...
+    "clang-format.executable": "/absolute/path/to/clang-format"
+}
+```
+
+Placeholders can also be used in the `clang-format.executable` value. 
+The following placeholders are supported:
+
+- `${workspaceRoot}` - replaced by the absolute path of the current vscode
+  workspace root.
+- `${cwd}` - replaced by the current working directory of vscode.
+- `${env.VAR}` - replaced by the environment variable $VAR, e.g. `${env.HOME}`
+  will be replaced by `$HOME`, your home directory. 
+
+Some examples:
+
+- `${workspaceRoot}/node_modules/.bin/clang-format` - specifies the version of
+  clang that has been added to your workspace by `npm install clang-format`.
+- `${env.HOME}/tools/clang38/clang-format` - use a specific clang format version
+  under your home directory.
 
 ## Source code
 Available on github: https://github.com/xaverh/vscode-clang-format-provider


### PR DESCRIPTION
This allows for specifying versions of clang-format which are found within the workspace, or on other paths rooted under environment variables. Fixes #19.