### PR TITLE
Add Handling for Objective-cpp Language Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-[Clang-Format](http://clang.llvm.org/docs/ClangFormat.html) is a tool to format C/C++/Java/JavaScript/Objective-C/Protobuf code. It can be configured with a config file within the working folder or a parent folder. Configuration see: http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+[Clang-Format](http://clang.llvm.org/docs/ClangFormat.html) is a tool to format C/C++/Java/JavaScript/Objective-C/Objective-C++/Protobuf code. It can be configured with a config file within the working folder or a parent folder. Configuration see: http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "onLanguage:cpp",
         "onLanguage:c",
         "onLanguage:objective-c",
+        "onLanguage:objective-cpp",
         "onLanguage:java",
         "onLanguage:javascript",
         "onLanguage:typescript",
@@ -98,6 +99,21 @@
                     "type": "string",
                     "default": "",
                     "description": "clang-format fallback style for Objective-C, left empty to use clang-format.fallbackStyle"
+                },
+                "clang-format.language.objective-cpp.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "enable formatting for Objective-C++ (requires reloading Visual Studio Code)"
+                },
+                "clang-format.language.objective-cpp.style": {
+                    "type": "string",
+                    "default": "",
+                    "description": "clang-format fallback style for Objective-C++, left empty to use clang-format.style"
+                },
+                "clang-format.language.objective-cpp.fallbackStyle": {
+                    "type": "string",
+                    "default": "",
+                    "description": "clang-format fallback style for Objective-C++, left empty to use clang-format.fallbackStyle"
                 },
                 "clang-format.language.java.enable": {
                     "type": "boolean",

--- a/src/clangMode.ts
+++ b/src/clangMode.ts
@@ -3,7 +3,7 @@
 import vscode = require('vscode');
 
 let languages: string[] = [];
-for (var l of ["cpp", "c", "objective-c", "java", "javascript", "typescript", "proto"]) {
+for (var l of ["cpp", "c", "objective-c", "objective-cpp", "java", "javascript", "typescript", "proto"]) {
 	if (vscode.workspace.getConfiguration("clang-format").get("language." + l + ".enable")) {
 		languages.push(l);
 	}


### PR DESCRIPTION
VSCode 1.11 and the current insiders builds introduce a new `objective-cpp` language mode for Objective-c++ (https://github.com/Microsoft/vscode/pull/21599). Previously, `.mm` files were treated as plain old c++.

This change adds support for the new Objective-C++ language mode to this extension

https://github.com/Microsoft/vscode/issues/21775