### PR TITLE
Evaluate placeholders in "clang-format.assumeFilename"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,14 @@ Some examples:
 - `${env.HOME}/tools/clang38/clang-format` - use a specific clang format version
   under your home directory.
 
+Placeholders are also supported in `clang-format.assumeFilename`. The supported
+placeholders are `${file}`, `${fileNoExtension}`, `${fileBasename}`,
+`${fileBasenameNoExtension}`, and `${fileExtname}`, with the same meaning as the
+predefined variables in [other configuration files](https://code.visualstudio.com/docs/editor/variables-reference).
+
+For example:
+- `${fileNoExtension}.cpp` - `/home/src/foo.h` will be formatted with
+  `-assume-filename /home/src/foo.cpp`.
+
 ## Source code
 Available on github: https://github.com/xaverh/vscode-clang-format-provider

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,7 +171,14 @@ export class ClangDocumentFormattingEditProvider implements vscode.DocumentForma
     if (assumedFilename === '') {
       return document.fileName;
     }
-    return assumedFilename;
+    let parsedPath = path.parse(document.fileName);
+    let fileNoExtension = path.join(parsedPath.dir, parsedPath.name);
+    return assumedFilename
+        .replace(/\${file}/g, document.fileName)
+        .replace(/\${fileNoExtension}/g, fileNoExtension)
+        .replace(/\${fileBasename}/g, parsedPath.base)
+        .replace(/\${fileBasenameNoExtension}/g, parsedPath.name)
+        .replace(/\${fileExtname}/g, parsedPath.ext);
   }
 
   private doFormatDocument(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {


### PR DESCRIPTION
This is halfway between a feature request and a PR.

`clang-format` has an annoying behaviour of deciding C++ headers are actually Objective-C. Since `clang-format` doesn't have an `-assume-language` option we're forced to abuse `-assume-filename` and format everything as though it was a `.cpp`. But we can't just call everything `dummy_filename.cpp` (when formatting `foo.cpp`, the formatter should recognise that `#include "foo.h"` is a special line). So we need to be able to substitute the current filename into the `-assume-filename` option.

I've added this substitution, along with some slices of the filename supported in other places. **But** I tested this manually in the exported JavaScript - I believe this change to the source Typescript does the same thing, but I don't know how the extension is built so haven't tested this.