### PR TITLE
Added platform specific executable settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,21 @@
           "default": "clang-format",
           "description": "clang-format executable path"
         },
+        "clang-format.executable.windows": {
+          "type": "string",
+          "default": "",
+          "description": "clang-format executable path on Windows"
+        },
+        "clang-format.executable.linux": {
+          "type": "string",
+          "default": "",
+          "description": "clang-format executable path on Linux"
+        },
+        "clang-format.executable.osx": {
+          "type": "string",
+          "default": "",
+          "description": "clang-format executable path on macOS"
+        },
         "clang-format.style": {
           "type": "string",
           "default": "file",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,16 @@ import sax = require('sax');
 
 export let outputChannel = vscode.window.createOutputChannel('Clang-Format');
 
+function getPlatformString() {
+  switch(process.platform) {
+    case 'win32': return 'windows';
+    case 'linux': return 'linux';
+    case 'darwin': return 'osx';
+  }
+
+  return 'unknown';
+}
+
 export class ClangDocumentFormattingEditProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider {
   private defaultConfigure = {
     executable: 'clang-format',
@@ -120,7 +130,13 @@ export class ClangDocumentFormattingEditProvider implements vscode.DocumentForma
   /// Get execute name in clang-format.executable, if not found, use default value
   /// If configure has changed, it will get the new value
   private getExecutablePath() {
-    let execPath = vscode.workspace.getConfiguration('clang-format').get<string>('executable');
+    let platform = getPlatformString();
+    let config = vscode.workspace.getConfiguration('clang-format');
+
+    let platformExecPath = config.get<string>('executable.' + platform);
+    let defaultExecPath = config.get<string>('executable');
+    let execPath = platformExecPath || defaultExecPath;
+
     if (!execPath) {
       return this.defaultConfigure.executable;
     }


### PR DESCRIPTION
This adds the ability to have platform specific clang-format executable paths. I based the configuration setting names on `terminal.integrated.shell.*` which uses platform names `'windows'`, '`linux'`, and `'osx'`. 

In our project we are using https://github.com/angular/clang-format which distributes clang-format binaries for windows, linux and macos through npmjs. It would be very handy for us to have these platform specific settings so we may commit our `.vscode/settings.json` into our repository with these pre-set.

Of course this PR wouldn't be necessary if https://github.com/microsoft/vscode/issues/5595 were resolved.