### PR TITLE
add support for C#

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "activationEvents": [
     "onLanguage:cpp",
     "onLanguage:c",
+    "onLanguage:csharp",
     "onLanguage:objective-c",
     "onLanguage:objective-cpp",
     "onLanguage:java",
@@ -91,6 +92,21 @@
           "type": "string",
           "default": "",
           "description": "clang-format fallback style for C, left empty to use clang-format.fallbackStyle"
+        },
+        "clang-format.language.csharp.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "enable formatting for C# (requires reloading Visual Studio Code)"
+        },
+        "clang-format.language.csharp.style": {
+          "type": "string",
+          "default": "",
+          "description": "clang-format fallback style for C#, left empty to use clang-format.style"
+        },
+        "clang-format.language.csharp.fallbackStyle": {
+          "type": "string",
+          "default": "Microsoft",
+          "description": "clang-format fallback style for C#, left empty to use clang-format.fallbackStyle"
         },
         "clang-format.language.objective-c.enable": {
           "type": "boolean",

--- a/src/clangMode.ts
+++ b/src/clangMode.ts
@@ -7,7 +7,7 @@ export const ALIAS = {
 };
 
 let languages: string[] = [];
-for (let l of ['cpp', 'c', 'objective-c', 'objective-cpp', 'java', 'javascript', 'typescript', 'proto', 'proto3', 'apex', 'glsl', 'hlsl', 'cuda']) {
+for (let l of ['cpp', 'c', 'csharp', 'objective-c', 'objective-cpp', 'java', 'javascript', 'typescript', 'proto', 'proto3', 'apex', 'glsl', 'hlsl', 'cuda']) {
   let confKey = `language.${ALIAS[l] || l}.enable`;
   if (vscode.workspace.getConfiguration('clang-format').get(confKey)) {
     languages.push(l);


### PR DESCRIPTION
Requires clang-format v9 or later. Fixes #95 