### PR TITLE
Feature: basic multi root support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The following placeholders are supported:
 
 - `${workspaceRoot}` - replaced by the absolute path of the current vscode
   workspace root.
+- `${workspaceFolder}` - replaced by the absolute path of the current vscode 
+  workspace. In case of outside-workspace files `${workspaceFolder}` expands 
+  to the absolute path of the first available workspace.
 - `${cwd}` - replaced by the current working directory of vscode.
 - `${env.VAR}` - replaced by the environment variable $VAR, e.g. `${env.HOME}`
   will be replaced by `$HOME`, your home directory.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.9.0",
   "publisher": "xaver",
   "engines": {
-    "vscode": "^1.1.0"
+    "vscode": "^1.15.0"
   },
   "galleryBanner": {
     "color": "#005577",


### PR DESCRIPTION
Some extensions (like [vscode-cmake-tools](https://github.com/microsoft/vscode-cmake-tools)) rely on `${workspaceFolder}` variable instead of `${workspaceRoot}` which is [marked as deprecated](https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented). This PR implements basic support for multi-root workspaces taking [basic-multi-root-sample](https://github.com/microsoft/vscode-extension-samples/tree/master/basic-multi-root-sample) as an example. 

This PR adds the support of `${workspaceFolder}` placeholder in the extension settings. To do so, I've bumped the vscode API to 1.15.0 -- earliest version that supports multi-root workspaces. 

Expansion itself consists of several steps:
1. In case there are no editors open the variable expands to `undefined` and error message is shown. In that case user is trying to format file which is not open and I believe that this is not actually possible. 
2. In case there are no workspaces at all - user is trying to use `${workspaceFolder}` variable when single file is opened - in that case an error message is emitted and `undefined` is used as variable value.
3. In case user formats file outside of the workspaces -- extension will assume that `${workspaceFolder}` should be the first workspace in the list and will expand the placeholder to the first workspace path. Warning message indicating that is shown too.
4. In case user formats file in the workspace -- workspace folder is deduced based on the file itselfs using vscode utilities. 