### PR TITLE
Add `cuda-cpp` to list of languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "onLanguage:apex",
     "onLanguage:glsl",
     "onLanguage:hlsl",
-    "onLanguage:cuda"
+    "onLanguage:cuda",
+    "onLanguage:cuda-cpp"
   ],
   "contributes": {
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -274,6 +274,21 @@
           "default": "",
           "description": "clang-format fallback style for CUDA, left empty to use clang-format.fallbackStyle"
         },
+        "clang-format.language.cuda-cpp.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "enable formatting for CUDA (requires reloading Visual Studio Code)"
+        },
+        "clang-format.language.cuda-cpp.style": {
+          "type": "string",
+          "default": "",
+          "description": "clang-format fallback style for CUDA, left empty to use clang-format.style"
+        },
+        "clang-format.language.cuda-cpp.fallbackStyle": {
+          "type": "string",
+          "default": "",
+          "description": "clang-format fallback style for CUDA, left empty to use clang-format.fallbackStyle"
+        },
         "clang-format.assumeFilename": {
           "type": "string",
           "default": "",

--- a/src/clangMode.ts
+++ b/src/clangMode.ts
@@ -7,7 +7,7 @@ export const ALIAS = {
 };
 
 let languages: string[] = [];
-for (let l of ['cpp', 'c', 'csharp', 'objective-c', 'objective-cpp', 'java', 'javascript', 'typescript', 'proto', 'proto3', 'apex', 'glsl', 'hlsl', 'cuda']) {
+for (let l of ['cpp', 'c', 'csharp', 'objective-c', 'objective-cpp', 'java', 'javascript', 'typescript', 'proto', 'proto3', 'apex', 'glsl', 'hlsl', 'cuda', 'cuda-cpp']) {
   let confKey = `language.${ALIAS[l] || l}.enable`;
   if (vscode.workspace.getConfiguration('clang-format').get(confKey)) {
     languages.push(l);


### PR DESCRIPTION
The [vscode-clangd](https://github.com/clangd/vscode-clangd) plugin [recently changed](https://github.com/clangd/vscode-clangd/blob/21cc1a5ad494c5f1f9a728c9ee7e1eab5e22a2a9/package.json#L28) their CUDA language identifier from `cuda` to `cuda-cpp`.

This change ensures this plugin can also activate if the user sets `"files.associations": { "*.cu": "cuda-cpp", "*.cuh": "cuda-cpp" }`.