### PR TITLE
Substitute `${env.X}` with an empty string for unset environment variables

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ export class ClangDocumentFormattingEditProvider implements vscode.DocumentForma
       .replace(/\${workspaceFolder}/g, this.getWorkspaceFolder())
       .replace(/\${cwd}/g, process.cwd())
       .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => {
-        return process.env[envName];
+        return process.env[envName] || '';
       });
   }
 


### PR DESCRIPTION
Change how `${env.X}` blocks are handled so that if the variable `X` is not set, the block is replaced with an empty string. The existing behavior is that the `${env.X}` block is replaced with the literal string "undefined".

This makes this extension consistent with the behavior of VSCode itself, which substitutes an empty string for unset environment variables:

<details>

<summary>VSCode behavior examples</summary>

VSCode's behavior is not really documented (their [variable reference](https://code.visualstudio.com/docs/reference/variables-reference#_environment-variables) page doesn't say anything about what happens when an env var is unset). However there are a number of ways it can be observed while using VSCode.

#### Example 1: `tasks.json`

1. Put the following in `.vscode/tasks.json`:
```jsonc
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "echo vars",
            "type": "shell",
            "command": "echo 'UNSET_VAR=(${env:UNSET_VAR}), HOME=(${env:HOME})'",
        }
    ]
}
```

2. In the command palette , select "Tasks: Run Task", then select "echo vars".

3. Observe the terminal output:

```text
Executing task: echo 'UNSET_VAR=(), HOME=(/home/myname)' 

UNSET_VAR=(), HOME=(/home/myname)
```

#### Example 2: `settings.json`

1. Put the following in `.vscode/settings.json`:

```jsonc
{
    // Replace "linux" with "windows" or "osx" if you're on Windows or Mac
    "terminal.integrated.env.linux": {
        "MY_TEST": "UNSET_VAR=(${env:UNSET_VAR}), HOME=(${env:HOME})",
    }
}
```

2. Open a new terminal

3. Print out the value that VSCode set:
```shell
$ echo "$MY_TEST" 
UNSET_VAR=(), HOME=(/home/nelul)
```

As you can see, in both of these instances VSCode expands `${env:UNSET_VAR}` to the empty string. This behavior is consistent across everywhere that VSCode expands `${env:X}` blocks as far as I can tell.

</details>
